### PR TITLE
PM - Updating IAM policy for r53 entries, using name prefix instead o…

### DIFF
--- a/test/integration/default/tf_aws_cluster_eks.rb
+++ b/test/integration/default/tf_aws_cluster_eks.rb
@@ -11,12 +11,12 @@ describe command('aws eks describe-cluster --name ' + tfvars['cluster_name']) do
   its('stdout') { should include ("\"status\": \"ACTIVE\"") }                         # be active
 end
 
-describe command('aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names ' + tfvars['cluster_name'] + '-default-eks-asg') do
-  its('stdout') { should include ("\"AutoScalingGroupName\": \"" + tfvars['cluster_name'] + '-default-eks-asg') }   # exist
-  its('stdout') { should include ("\"LaunchConfigurationName\": \"" + tfvars['cluster_name'] + '-default') }        # have correct launch config
+describe command('aws autoscaling describe-auto-scaling-groups') do
+  its('stdout') { should include ("\"AutoScalingGroupName\": \"" + tfvars['cluster_name'] + '-') }   # exist
+  its('stdout') { should include ("\"LaunchConfigurationName\": \"" + tfvars['cluster_name'] + '-') }        # have correct launch config
 end
 
-describe command('aws autoscaling describe-launch-configurations --launch-configuration-names ' + tfvars['cluster_name'] + '-default') do
-  its('stdout') { should include ("\"LaunchConfigurationName\": \"" + tfvars['cluster_name'] + '-default') }  # exist
+describe command('aws autoscaling describe-launch-configurations') do
+  its('stdout') { should include ("\"LaunchConfigurationName\": \"" + tfvars['cluster_name'] + '-') }  # exist
   its('stdout') { should include ("\"InstanceType\": \"" + "t2.xlarge") }                                     # have correct default instance
 end


### PR DESCRIPTION
…f name for ASG and LaunchConfig


I'm really not thrilled with the tests as the statement checking the LaunchConfig is attache to the ASG in question, and the test ensuring the instance size for the LaunchConfig is correct has potential for false positives. But it fixes the issue with duplicate names and adds the r53 policy